### PR TITLE
Made mimetype negotiation much more spec compliant

### DIFF
--- a/flask_negotiate.py
+++ b/flask_negotiate.py
@@ -1,5 +1,8 @@
 
 from functools import wraps
+from itertools import groupby
+from operator import itemgetter
+from collections import defaultdict
 
 from flask import request
 from werkzeug.exceptions import UnsupportedMediaType, NotAcceptable
@@ -15,14 +18,68 @@ def consumes(*content_types):
         return wrapper
     return decorated
 
+def build_groups(acceptable):
+    """
+    Build the group information used by the MimeTypeMatcher
+
+    Returns a dictionary of String -> Set, which always includes the default top
+    type "*/*".
+    """
+    ret = defaultdict(lambda: set(['*']))
+    ret['*'].add('*')
+    for group, partsets in groupby((a.partition('/') for a in acceptable), itemgetter(0)):
+        for parts in partsets:
+            g, sep, species = parts
+            ret[group].add(species)
+    return ret
+
+class MimeTypeMatcher(object):
+    """
+    Matcher that contains the logic for deciding if a mimetype is acceptable.
+    -------------------------------------------------------------------------
+
+    One matcher will be constructed for each route, and used to assess the
+    mimetypes the client can accept, and determine whether this route can
+    meet the client's requirements.
+    """
+
+    def __init__(self, acceptable):
+        self.acceptable = set(str(a) for a in acceptable)
+        self.groups = build_groups(self.acceptable)
+
+    def is_acceptable(self, mimetype):
+        """
+        Test if a given mimetype is acceptable.
+        """
+        mt = str(mimetype)
+        if mimetype is None or mt.strip() == '':
+            return False
+        if mt in self.acceptable:
+            return True
+        genus, _, species = mt.partition('/')
+        if genus in self.groups:
+            return species in self.groups[genus]
+        return False
 
 def produces(*content_types):
+    """
+    Annotate a route as only acceptable for clients that can accept the given content types.
+    ----------------------------------------------------------------------------------------
+
+    content_types: list of mimetype strings, eg: "text/html", "application/json"
+
+    Clients that can accept at least one of the given content types will be allowed
+    to run the route. This means both exact content type matches as well as wild card matches,
+    so that a client that accepts '*/*' will always be permitted access, and one that
+    specifies 'text/*' to an HTML route will also be allowed to proceed.
+    """
     def decorated(fn):
+        matcher = MimeTypeMatcher(content_types)
         @wraps(fn)
         def wrapper(*args, **kwargs):
             requested = set(request.accept_mimetypes.values())
-            defined = set(content_types)
-            if len(requested & defined) == 0:
+            acceptable = filter(matcher.is_acceptable, requested)
+            if len(acceptable) == 0:
                 raise NotAcceptable()
             return fn(*args, **kwargs)
         return wrapper

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Negotiate',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/mattupstate/flask-negotiate',
     license='MIT',
     author='Matthew Wright',

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,8 @@ from flask_negotiate import consumes, produces
 HTML = 'text/html'
 JSON = 'application/json'
 XML = 'application/xml'
+ANY_TEXT = 'text/*'
+ANY = '*/*'
 
 UNSUPPORTED_CODE = 415
 NOT_ACCEPTABLE_CODE = 406
@@ -18,6 +20,8 @@ PRODUCES_JSON_AND_HTML = '/produces_json_and_html'
 HTML_HEADERS = {'Accept': HTML}
 JSON_HEADERS = {'Accept': JSON}
 XML_HEADERS = {'Accept': XML}
+ANY_HEADERS = {'Accept': ANY}
+ANY_TEXT_HEADERS = {'Accept': ANY_TEXT}
 
 
 class NegotiateTestCase(unittest.TestCase):
@@ -89,3 +93,12 @@ class NegotiateTestCase(unittest.TestCase):
     def test_produces_json_and_html_ivalid_accept(self):
         r = self.client.get(PRODUCES_JSON_AND_HTML, headers=XML_HEADERS)
         self.assertUnacceptable(r)
+
+    def test_produces_json_only_accept_any(self):
+        r = self.client.get(PRODUCES_JSON_ONLY, headers = ANY_HEADERS)
+        self.assertIn(PRODUCES_JSON_ONLY, r.data)
+
+    def test_produces_json_and_html_accept_any_text(self):
+        r = self.client.get(PRODUCES_JSON_AND_HTML, headers=ANY_TEXT_HEADERS)
+        self.assertIn(PRODUCES_JSON_AND_HTML, r.data)
+


### PR DESCRIPTION
The current implementation only permits exact matches on mimetype strings, whereas Accept headers may contain wild cards (such as `text/*`, up to `*/*`). This pull request includes tests, code and documentation to add the capacity to deal with wildcards. All current tests remain as they were, so the current behaviour should not break for anyone. I have also bumped the minor version to reflect the API change.
